### PR TITLE
Use abspath to ensure an absolute path to the pex for kernel execution.

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # pexnb
 
-Entrypoint for launching notebooks with PEX
+Entrypoint for launching jupyter notebooks from a pex
 
 Modifies the default KernelSpecManager to:
 
@@ -12,8 +12,4 @@ Use it:
     pip install pex
     pex notebook pexnb -m pexnb -o ./nb.pex
 
-    $PWD/nb.pex
-
-Notes:
-
-- Resulting .pex **must** be invoked by absolute path, otherwise the .pex file cannot be found.
+    ./nb.pex

--- a/pexnb.py
+++ b/pexnb.py
@@ -3,13 +3,15 @@
 Launches Jupyter notebook with a PEX-compatible
 KernelSpecManager that appropriately invokes subprocesses with PEX.
 """
+import os
 import sys
 
 from jupyter_client.kernelspec import KernelSpecManager, NATIVE_KERNEL_NAME
 
+
 class PEXKernelSpecManager(KernelSpecManager):
     """KernelSpecManager that is compatible with PEX
-    
+
     Only the native kernelspec will be present.
     The .pex file must have been invoked by absolute path,
     otherwise it won't be found.
@@ -23,12 +25,10 @@ class PEXKernelSpecManager(KernelSpecManager):
         spec = super(PEXKernelSpecManager, self).get_kernel_spec(kernel_name)
         if kernel_name == NATIVE_KERNEL_NAME:
             # rewrite native kernelspec for PEX
-            # Assumes sys.argv[0] is the abspath to the .pex file,
-            # otherwise this won't work.
-            # If the .pex is launched with 
-            spec.argv = [sys.argv[0], '-f', '{connection_file}']
+            spec.argv = [os.path.abspath(sys.argv[0]), '-f', '{connection_file}']
             spec.env['PEX_MODULE'] = 'ipykernel_launcher'
         return spec
+
 
 if __name__ == '__main__':
     from notebook.notebookapp import NotebookApp


### PR DESCRIPTION
This eliminates the requirement to run the pex via an absolute path and cleans up the docs to reflect.